### PR TITLE
track current db in Apartment.connection_config for accurate context management

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -87,7 +87,7 @@ module Apartment
       #         complete info of a database, :database, :host, ...
       #   {Boolean} choose if use USE statement while switching to the database_config
       def process(database_config = nil, use_use=true)
-        current_db = current_database
+        current_db = current_database.dup
 
         switch(database_config, use_use)
 

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -19,19 +19,6 @@ module Apartment
         end
       end
 
-      # Maintain current database name being used
-      # This is necessary because our connection pooling ignores database name and we have
-      # no direct reference to db name (we simply call "USE [database]" for db switching)
-      # Keeping the database name in thread current to be thread safe and relying on this
-      # value being set every time db connection changes (see connect_to_new method in this class)
-      def current_database_name
-        Thread.current[:apartment_current_database_name]
-      end
-
-      def current_database_name=(name)
-        Thread.current[:apartment_current_database_name] = name
-      end
-
     protected
 
       #   Connect to new database
@@ -43,18 +30,25 @@ module Apartment
       #     {Boolean} use_use, if use USE statement. In creation process, we do not want to use use since there is not db to use.
       #   ---------------------------------------
       def connect_to_new(database_config, use_use)
-
-        # Step1: using establish_connection to retrieve/start a connection to the db server.
+        # use establish_connection to retrieve/start a connection to the db server
         Apartment.establish_connection database_config
 
-        # Step2: use "USE" to connect to the desired database.
-        # the only situation that :target_database is nil that database_config is the dummy default config.
-        self.current_database_name = database_config[:database]
         #Use preloaded schema_cache to avoid problems during migrations
         Apartment.connection.schema_cache = Apartment::Database.schema_cache if Apartment::Database.schema_cache
+
+        # use "USE" statement to connect to the desired database.
+        # the only situation that :target_database should be nil
+        # is when database_config is the dummy default config and :database is not nil
         if database_config[:target_database] && use_use
           Apartment.connection.execute "USE #{database_config[:target_database]}"
-          self.current_database_name = database_config[:target_database]
+
+          # modify the target_database in the cached config to represent the most recent
+          # this becomes necessary for calls like #process, which rely on the cached value
+          # for connection restore
+          Apartment.connection_config[:target_database] = database_config[:target_database]
+        else
+          # set target_database in cached db config so #current_database_name is accurate
+          Apartment.connection_config[:target_database] = Apartment.connection_config[:database]
         end
 
       rescue Mysql2::Error, ActiveRecord::StatementInvalid


### PR DESCRIPTION
This approach updates the `:target_database` value directly in the hash cached by ActiveRecord. I confirmed that our override to `ActiveRecord::ConnectionAdapters::ConnectionHandler` only considers host, database, and port (i.e. not the entire hash) for connection pooling, so modifying the `:target_database` value should not affect ActiveRecord behavior.

This approach is the cleanest from a code perspective, as I was even able to remove the `current_database_name` override in the mysql2 adapter and allow the value to always be pulled from `Apartment.current_config[:target_database]`. 
That said, there's something creepy about changing the value in a cached hash. Thus, option2 was born. I'm open to either approach and defer to the group for our final solution.